### PR TITLE
Fairly major bacon.js input/output overhaul 

### DIFF
--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -1,95 +1,16 @@
-import * as Bacon from "baconjs";
-import type { StateF } from "baconjs/types/withstatemachine";
-import {
-  PACKET_FLAG_DEVICE_INFO,
-  PACKET_FLAG_END_OF_COMMAND,
-  PACKET_FLAG_HOST_CMD_FINISHED,
-  PACKET_FLAG_START_OF_COMMAND,
-} from "./packet";
-
-// TODO: Probably move all this bacon packet stuff to `packet.js`?
-interface PacketHandlingState {
-  currentPacket: Uint8Array;
-}
-
-function hasValue<T>(ev: Bacon.Event<T>): ev is Bacon.Value<T> {
-  return ev.hasValue;
-}
-
-export type Packet = { type: "host_cmd_finished"; payload: [] } | { type: "data"; payload: Uint8Array };
-
-/**
- * Gets called when a packet is received, returns a tuple of new state and an array of
+/*
+ * This file exports our public API to external consumers
  */
-export const handlePacket: StateF<DataView, PacketHandlingState, Packet> = (state, event) => {
-  if (!hasValue(event)) {
-    console.log("No Event Value");
-    return [state, []];
-  }
 
-  let currentPacket = state.currentPacket;
-  const data = new Uint8Array(event.value.buffer);
-
-  // console.log("Raw Packet Data: ", data);
-
-  // Return if packet is empty
-  if (data.length <= 3) {
-    console.log("Empty Packet");
-    return [state, []];
-  }
-  const cmd = data[0];
-  const byte_len = data[1];
-
-  if (cmd & PACKET_FLAG_DEVICE_INFO) {
-    // This is a response to RequestDeviceInfo. Since any application can send this,
-    // we ignore the packet if we didn't request it, since it might be requested
-    // for a different program.
-    // TODO: Handle this? Not sure there's anything to handle here tbh
-    console.log("Found Packet Flag Device Info");
-  }
-
-  // TODO: Make some consts for these 2's everywhere
-  if (2 + byte_len > data.length) {
-    // TODO: Can this even happen???
-    console.log("Communication Error: Oversized Packet (ignored)");
-    return [state, []];
-  }
-
-  // The data exists after the first 2 bytes
-  const dataBody = data.slice(2, 2 + byte_len);
-
-  if ((cmd & PACKET_FLAG_START_OF_COMMAND) === PACKET_FLAG_START_OF_COMMAND && state.currentPacket.length > 0) {
-    /**
-     * When we get a start packet, the read buffer should already be empty. If it isn't,
-     * we got a command that didn't end with an END_OF_COMMAND packet and something is wrong.
-     * This shouldn't happen, so warn about it and recover by clearing the junk in the buffer.
-     * TODO: Again, does this actually happen???!?
-     */
-    console.log(
-      "Got PACKET_FLAG_OF_START_COMMAND, but we had ${current_packet.length} bytes in the buffer. Dropping it and continuing.",
-    );
-    currentPacket = new Uint8Array(0);
-  }
-
-  // concat the new data onto the current packet
-  const nextPacket = new Uint8Array(currentPacket.byteLength + dataBody.byteLength);
-  nextPacket.set(currentPacket);
-  nextPacket.set(dataBody, currentPacket.byteLength);
-  const eventsToPass: Packet[] = [];
-
-  let newState = { currentPacket: nextPacket };
-
-  // Note that if PACKET_FLAG_HOST_CMD_FINISHED is set, PACKET_FLAG_END_OF_COMMAND will also be set
-  if ((cmd & PACKET_FLAG_HOST_CMD_FINISHED) === PACKET_FLAG_HOST_CMD_FINISHED) {
-    // This tells us that a command we wrote to the device has finished executing, and it's safe to start writing another.
-    //console.log("Packet Complete");
-    eventsToPass.push({ type: "host_cmd_finished", payload: [] });
-  }
-
-  if ((cmd & PACKET_FLAG_END_OF_COMMAND) === PACKET_FLAG_END_OF_COMMAND) {
-    newState = { currentPacket: new Uint8Array(0) };
-    eventsToPass.push({ type: "data", payload: nextPacket });
-  }
-
-  return [newState, eventsToPass.map((e) => new Bacon.Next(e))];
-};
+export {
+  SMX_USB_PRODUCT_ID,
+  SMX_USB_PRODUCT_NAME,
+  SMX_USB_VENDOR_ID,
+  Sensor,
+  Panel,
+  SENSOR_COUNT,
+  PANEL_COUNT,
+} from "./api.js";
+export { type PanelName } from "./commands/inputs.js";
+export { SensorTestMode, type SMXPanelTestData, type SMXSensorTestData } from "./commands/sensor_test.js";
+export { SMXStage } from "./smx.js";

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -11,6 +11,6 @@ export {
   SENSOR_COUNT,
   PANEL_COUNT,
 } from "./api.js";
-export { type PanelName } from "./commands/inputs.js";
+export { type PanelName, type EachPanel } from "./commands/inputs.js";
 export { SensorTestMode, type SMXPanelTestData, type SMXSensorTestData } from "./commands/sensor_test.js";
 export { SMXStage } from "./smx.js";

--- a/sdk/packet.ts
+++ b/sdk/packet.ts
@@ -101,7 +101,7 @@ export function make_packets(data: Array<number>): Array<Uint8Array> {
   return packets;
 }
 
-export async function requestSpecialDeviceInfo(dev: HIDDevice, debug = false) {
+export async function makeSpecialDevicePacket(dev: HIDDevice, debug = false) {
   const packet = pad_packet([PACKET_FLAG_DEVICE_INFO]);
 
   if (debug) {

--- a/sdk/smx.ts
+++ b/sdk/smx.ts
@@ -74,7 +74,6 @@ class SMXEvents {
   }
 
   private async writeToHID(value: Array<number>) {
-    //this.startedSend$.push(true);
     console.log("writing to HID");
     await send_data(this.dev, value);
   }
@@ -117,7 +116,7 @@ export class SMXStage {
     this.events.inputState$.onValue((value) => this.handleInputs(value));
   }
 
-  async init() {
+  async init(): Promise<SMXConfig> {
     /**
      * This is a special RequestDeviceInfo packet. This is the same as sending an
      * 'i' command, but we can send it safely at any time, even if another
@@ -127,23 +126,23 @@ export class SMXStage {
 
     this.updateDeviceInfo();
 
-    // Request the config for this stage
-    this.updateConfig();
-
     // Request some initial test data
     this.updateTestData();
+
+    // Request the config for this stage
+    return this.updateConfig();
   }
 
   updateDeviceInfo() {
     this.events.output$.push([API_COMMAND.GET_DEVICE_INFO]);
   }
 
-  updateConfig() {
+  updateConfig(): Promise<SMXConfig> {
     this.events.output$.push([API_COMMAND.GET_CONFIG_V5]);
     return this.configResponse$.firstToPromise();
   }
 
-  updateTestData(mode: SensorTestMode | null = null) {
+  updateTestData(mode: SensorTestMode | null = null): void {
     if (mode) {
       this.test_mode = mode;
     }

--- a/sdk/state-machines/collate-packets.ts
+++ b/sdk/state-machines/collate-packets.ts
@@ -5,6 +5,7 @@ import {
   PACKET_FLAG_END_OF_COMMAND,
   PACKET_FLAG_HOST_CMD_FINISHED,
   PACKET_FLAG_START_OF_COMMAND,
+  PACKET_PREAMBLE_SIZE,
 } from "../packet";
 
 interface PacketHandlingState {
@@ -18,6 +19,7 @@ export type Packet = { type: "host_cmd_finished" } | DataPacket;
  * Gets called when a packet is received, returns a tuple of new state and an array of
  */
 export const collatePackets: StateF<DataView, PacketHandlingState, Packet> = (state, event) => {
+  // TODO: This whole function could maybe just use a bit more comments
   if (!Bacon.hasValue(event)) {
     console.log("No Event Value");
     return [state, []];
@@ -29,7 +31,7 @@ export const collatePackets: StateF<DataView, PacketHandlingState, Packet> = (st
   // console.log("Raw Packet Data: ", data);
 
   // Return if packet is empty
-  if (data.length <= 3) {
+  if (data.length <= PACKET_PREAMBLE_SIZE) {
     console.log("Empty Packet");
     return [state, []];
   }
@@ -44,8 +46,7 @@ export const collatePackets: StateF<DataView, PacketHandlingState, Packet> = (st
     console.log("Found Packet Flag Device Info");
   }
 
-  // TODO: Make some consts for these 2's everywhere
-  if (2 + byte_len > data.length) {
+  if (PACKET_PREAMBLE_SIZE + byte_len > data.length) {
     // TODO: Can this even happen???
     console.log("Communication Error: Oversized Packet (ignored)");
     return [state, []];

--- a/sdk/state-machines/collate-packets.ts
+++ b/sdk/state-machines/collate-packets.ts
@@ -1,0 +1,91 @@
+import * as Bacon from "baconjs";
+import type { StateF } from "baconjs/types/withstatemachine";
+import {
+  PACKET_FLAG_DEVICE_INFO,
+  PACKET_FLAG_END_OF_COMMAND,
+  PACKET_FLAG_HOST_CMD_FINISHED,
+  PACKET_FLAG_START_OF_COMMAND,
+} from "../packet";
+
+interface PacketHandlingState {
+  currentPacket: Uint8Array;
+}
+
+export type DataPacket = { type: "data"; payload: Uint8Array };
+export type Packet = { type: "host_cmd_finished" } | DataPacket;
+
+/**
+ * Gets called when a packet is received, returns a tuple of new state and an array of
+ */
+export const collatePackets: StateF<DataView, PacketHandlingState, Packet> = (state, event) => {
+  if (!Bacon.hasValue(event)) {
+    console.log("No Event Value");
+    return [state, []];
+  }
+
+  let currentPacket = state.currentPacket;
+  const data = new Uint8Array(event.value.buffer);
+
+  // console.log("Raw Packet Data: ", data);
+
+  // Return if packet is empty
+  if (data.length <= 3) {
+    console.log("Empty Packet");
+    return [state, []];
+  }
+  const cmd = data[0];
+  const byte_len = data[1];
+
+  if (cmd & PACKET_FLAG_DEVICE_INFO) {
+    // This is a response to RequestDeviceInfo. Since any application can send this,
+    // we ignore the packet if we didn't request it, since it might be requested
+    // for a different program.
+    // TODO: Handle this? Not sure there's anything to handle here tbh
+    console.log("Found Packet Flag Device Info");
+  }
+
+  // TODO: Make some consts for these 2's everywhere
+  if (2 + byte_len > data.length) {
+    // TODO: Can this even happen???
+    console.log("Communication Error: Oversized Packet (ignored)");
+    return [state, []];
+  }
+
+  // The data exists after the first 2 bytes
+  const dataBody = data.slice(2, 2 + byte_len);
+
+  if ((cmd & PACKET_FLAG_START_OF_COMMAND) === PACKET_FLAG_START_OF_COMMAND && state.currentPacket.length > 0) {
+    /**
+     * When we get a start packet, the read buffer should already be empty. If it isn't,
+     * we got a command that didn't end with an END_OF_COMMAND packet and something is wrong.
+     * This shouldn't happen, so warn about it and recover by clearing the junk in the buffer.
+     * TODO: Again, does this actually happen???!?
+     */
+    console.log(
+      "Got PACKET_FLAG_OF_START_COMMAND, but we had ${current_packet.length} bytes in the buffer. Dropping it and continuing.",
+    );
+    currentPacket = new Uint8Array(0);
+  }
+
+  // concat the new data onto the current packet
+  const nextPacket = new Uint8Array(currentPacket.byteLength + dataBody.byteLength);
+  nextPacket.set(currentPacket);
+  nextPacket.set(dataBody, currentPacket.byteLength);
+  const eventsToPass: Packet[] = [];
+
+  let newState = { currentPacket: nextPacket };
+
+  // Note that if PACKET_FLAG_HOST_CMD_FINISHED is set, PACKET_FLAG_END_OF_COMMAND will also be set
+  if ((cmd & PACKET_FLAG_HOST_CMD_FINISHED) === PACKET_FLAG_HOST_CMD_FINISHED) {
+    // This tells us that a command we wrote to the device has finished executing, and it's safe to start writing another.
+    //console.log("Packet Complete");
+    eventsToPass.push({ type: "host_cmd_finished" });
+  }
+
+  if ((cmd & PACKET_FLAG_END_OF_COMMAND) === PACKET_FLAG_END_OF_COMMAND) {
+    newState = { currentPacket: new Uint8Array(0) };
+    eventsToPass.push({ type: "data", payload: nextPacket });
+  }
+
+  return [newState, eventsToPass.map((e) => new Bacon.Next(e))];
+};

--- a/ui/pad-coms.ts
+++ b/ui/pad-coms.ts
@@ -1,5 +1,4 @@
-import { SMX_USB_PRODUCT_ID, SMX_USB_VENDOR_ID } from "../sdk/api";
-import { SMXStage } from "../sdk/smx";
+import { SMX_USB_PRODUCT_ID, SMX_USB_VENDOR_ID, SMXStage } from "../sdk";
 import { stages$, nextStatusTextLine$, statusText$, uiState } from "./state";
 
 export async function promptSelectDevice() {

--- a/ui/stage/fsr-panel.tsx
+++ b/ui/stage/fsr-panel.tsx
@@ -1,6 +1,5 @@
 import cn from "classnames";
-import type { SMXPanelTestData } from "../../sdk/commands/sensor_test";
-import { Sensor } from "../../sdk/api";
+import { Sensor, type SMXPanelTestData } from "../../sdk";
 
 interface EnabledProps {
   data: SMXPanelTestData;

--- a/ui/stage/stage-test.tsx
+++ b/ui/stage/stage-test.tsx
@@ -1,10 +1,14 @@
 import { useAtomValue, type Atom } from "jotai";
 import { useEffect, useState } from "react";
-import { SensorTestMode, type SMXPanelTestData, type SMXSensorTestData } from "../../sdk/commands/sensor_test";
 import { FsrPanel } from "./fsr-panel";
-import { StageInputs, type EachPanel, type PanelName } from "../../sdk/commands/inputs";
+import {
+  type PanelName,
+  type SMXStage,
+  SensorTestMode,
+  type SMXPanelTestData,
+  type SMXSensorTestData,
+} from "../../sdk/";
 import { displayTestData$ } from "../state";
-import type { SMXStage } from "../../sdk/smx";
 
 /*
 function useInputState(dev: HIDDevice | undefined) {

--- a/ui/stage/stage-test.tsx
+++ b/ui/stage/stage-test.tsx
@@ -36,7 +36,9 @@ function useTestData(stage: SMXStage | undefined) {
     async function update() {
       await d.updateTestData(SensorTestMode.CalibratedValues);
       setTestData(d.test);
-      handle = requestAnimationFrame(update);
+      if (readTestData) {
+        handle = requestAnimationFrame(update);
+      }
     }
 
     let handle = setInterval(update, 50);

--- a/ui/stage/stage-test.tsx
+++ b/ui/stage/stage-test.tsx
@@ -7,25 +7,18 @@ import {
   SensorTestMode,
   type SMXPanelTestData,
   type SMXSensorTestData,
+  type EachPanel,
 } from "../../sdk/";
 import { displayTestData$ } from "../state";
 
-/*
-function useInputState(dev: HIDDevice | undefined) {
+function useInputState(stage: SMXStage | undefined) {
   const [panelStates, setPanelStates] = useState<EachPanel<boolean> | undefined>();
   useEffect(() => {
-    if (!dev) return;
-    function handleInputReport(e: HIDInputReportEvent) {
-      if (e.reportId !== HID_REPORT_INPUT_STATE) return;
-      const state = StageInputs.decode(e.data, true);
-      setPanelStates(state);
-    }
-    dev.addEventListener("inputreport", handleInputReport);
-    return () => dev.removeEventListener("inputreport", handleInputReport);
-  }, [dev]);
+    if (!stage) return;
+    return stage.events.inputState$.onValue(setPanelStates);
+  }, [stage]);
   return panelStates;
 }
-*/
 
 function useTestData(stage: SMXStage | undefined) {
   const readTestData = useAtomValue(displayTestData$);
@@ -60,7 +53,7 @@ export function StageTest({
 }) {
   const stage = useAtomValue(stageAtom);
   const testData = useTestData(stage);
-  // const inputState = useInputState(stage);
+  const inputState = useInputState(stage);
 
   if (!testData) {
     return null;
@@ -71,7 +64,7 @@ export function StageTest({
   return (
     <div className="pad">
       {entries.map(([key, data]) => (
-        <FsrPanel active={false} key={key} data={data} />
+        <FsrPanel active={inputState?.[key]} key={key} data={data} />
       ))}
     </div>
   );

--- a/ui/stage/stage-test.tsx
+++ b/ui/stage/stage-test.tsx
@@ -4,14 +4,24 @@ import { FsrPanel } from "./fsr-panel";
 import { type SMXStage, SensorTestMode, type SMXPanelTestData, type SMXSensorTestData } from "../../sdk/";
 import { displayTestData$ } from "../state";
 
+// UI Update Rate in Milliseconds
+const UI_UPDATE_RATE = 50;
+
 function useInputState(stage: SMXStage | undefined) {
-  const [panelStates, setPanelStates] = useState<Array<boolean> | undefined>();
-  const inputs = stage?.inputs || undefined;
+  const [panelStates, setPanelStates] = useState<Array<boolean> | null>();
 
   useEffect(() => {
     if (!stage) return;
-    return setPanelStates(inputs); //TODO: Figure out why this feels laggy?
-  }, [stage, inputs]);
+
+    const d = stage;
+    async function update() {
+      setPanelStates(d.inputs);
+    }
+
+    const handle = setInterval(update, UI_UPDATE_RATE);
+    return () => clearInterval(handle);
+  }, [stage]);
+
   return panelStates;
 }
 
@@ -30,7 +40,7 @@ function useTestData(stage: SMXStage | undefined) {
       setTestData(d.test);
     }
 
-    const handle = setInterval(update, 50);
+    const handle = setInterval(update, UI_UPDATE_RATE);
     return () => clearInterval(handle);
   }, [stage, readTestData]);
 
@@ -46,7 +56,7 @@ export function StageTest({
   const testData = useTestData(stage);
   const inputState = useInputState(stage);
 
-  if (!testData) {
+  if (!testData || !inputState) {
     return null;
   }
 

--- a/ui/state.ts
+++ b/ui/state.ts
@@ -1,5 +1,5 @@
 import { atom, createStore } from "jotai";
-import type { SMXStage } from "../sdk/smx";
+import type { SMXStage } from "../sdk";
 
 export const browserSupported = "hid" in navigator;
 


### PR DESCRIPTION
Various changes and fixes mostly regarding using Bacon.js as the event handler for USB input/output.

Changes:
- Clean up dead code
- `sdk/index.ts` changed to just export the public API
- major changes to `sdk/smx.ts Bacon.js` event streams to handle input/output properly
- Allow SMXStage.updateConfig to return a promise so we can wait until we get a response to the config request (used on initialization)
- Handle stage inputs properly (when a panel is pressed)
- Move packet handling statemachine to `sdk/state-machines/collate-packets.ts`
- Add UI throttling for stage input states 
- Fix test data checkbox to properly stop requesting/updating test data when it is unchecked. 
- 
- Pass in `isFsr` to the Panel Test Data constructor so we know how to return the test data as FSRs are treated differently than LoadCells.