### PR TITLE
Add code to read/write/convert old config

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Noah Manneschmidt <noah@manneschmidt.net>",
   "license": "MIT",
   "dependencies": {
-    "@nmann/struct-buffer": "^5.4.0",
+    "@nmann/struct-buffer": "^5.4.1",
     "baconjs": "patch:baconjs@npm%3A3.0.17#~/.yarn/patches/baconjs-npm-3.0.17-1a95474784.patch",
     "classnames": "^2.5.1",
     "jotai": "^2.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -587,10 +587,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nmann/struct-buffer@npm:^5.4.0":
-  version: 5.4.0
-  resolution: "@nmann/struct-buffer@npm:5.4.0"
-  checksum: 10c0/f47ee36659e805831aadd3e2f2b75dffb00c0540c9f09a2ee7ea3f99de12b0ab0bd3ea53038893cbb5cb6e8463cee94e548ea4c45a8b98a555cdaa87f4abff9e
+"@nmann/struct-buffer@npm:^5.4.1":
+  version: 5.4.1
+  resolution: "@nmann/struct-buffer@npm:5.4.1"
+  checksum: 10c0/7f5974c34f0b5c27b4f20b423e90c51fa91aef7578e8af285856a4049809c83e569aa44680fefbfd72fd41580b269479511cabdc6112d7a8b7c2b8481b5eed08
   languageName: node
   linkType: hard
 
@@ -2466,7 +2466,7 @@ __metadata:
   resolution: "smx-config-web@workspace:."
   dependencies:
     "@biomejs/biome": "npm:1.6.4"
-    "@nmann/struct-buffer": "npm:^5.4.0"
+    "@nmann/struct-buffer": "npm:^5.4.1"
     "@types/react": "npm:^18.2.75"
     "@types/react-dom": "npm:^18.2.23"
     "@types/w3c-web-hid": "npm:1.0.6"


### PR DESCRIPTION
Send/Receive old config if firmware version < 5.

Type checking seems broken for array objects in `StructBuffers` so we should probably fix that before merging this in 