### PR TITLE
Some minor UI cleanup and polish

### DIFF
--- a/ui/DebugCommands.tsx
+++ b/ui/DebugCommands.tsx
@@ -1,15 +1,14 @@
 import { useAtomValue } from "jotai";
 import { useState } from "react";
 import { DEBUG_COMMANDS } from "./pad-coms";
-import { stages$ } from "./state.ts";
+import { selectedStage$ } from "./state.ts";
 import { RGB } from "../sdk/utils.ts";
 
+const cmds = Array.from(Object.entries(DEBUG_COMMANDS));
+
 export function DebugCommands() {
-  const connectedStages = useAtomValue(stages$);
-  const [selectedPlayer, setSelectedPlayer] = useState(0);
+  const stage = useAtomValue(selectedStage$);
   const [selectedCommand, setSelectedCommand] = useState<keyof typeof DEBUG_COMMANDS | "">("");
-  const cmds = Array.from(Object.entries(DEBUG_COMMANDS));
-  const stage = connectedStages[selectedPlayer];
   const handleSendCommand =
     selectedCommand && stage
       ? async () => {
@@ -25,17 +24,6 @@ export function DebugCommands() {
       : undefined;
   return (
     <>
-      <select value={selectedPlayer} onChange={(e) => setSelectedPlayer(Number(e.target.value))}>
-        <option disabled value="0">
-          Select Stage
-        </option>
-        <option value="1" disabled={!connectedStages[1]}>
-          Player 1
-        </option>
-        <option value="2" disabled={!connectedStages[2]}>
-          Player 2
-        </option>
-      </select>{" "}
       <select
         value={selectedCommand}
         onChange={(e) => setSelectedCommand(e.currentTarget.value as typeof selectedCommand)}

--- a/ui/pad-coms.ts
+++ b/ui/pad-coms.ts
@@ -11,10 +11,10 @@ export async function promptSelectDevice() {
     return;
   }
 
-  await open_smx_device(devices[0]);
+  await open_smx_device(devices[0], true);
 }
 
-export async function open_smx_device(dev: HIDDevice) {
+export async function open_smx_device(dev: HIDDevice, autoSelect = false) {
   if (!dev.opened) {
     await dev.open();
   }
@@ -34,11 +34,13 @@ export async function open_smx_device(dev: HIDDevice) {
       [serial]: stage, // TODO: Is there a better way to handle this?
     };
   });
-  uiState.set(selectedStageSerial$, serial);
   uiState.set(
     nextStatusTextLine$,
     `status: device opened: ${dev.productName}:P${stage.info?.player}:${stage.info?.serial}`,
   );
+  if (autoSelect) {
+    uiState.set(selectedStageSerial$, serial);
+  }
 }
 
 /**

--- a/ui/pad-coms.ts
+++ b/ui/pad-coms.ts
@@ -31,7 +31,7 @@ export async function open_smx_device(dev: HIDDevice, autoSelect = false) {
   uiState.set(stages$, (stages) => {
     return {
       ...stages,
-      [serial]: stage, // TODO: Is there a better way to handle this?
+      [serial]: stage,
     };
   });
   uiState.set(

--- a/ui/stage/fsr-panel.tsx
+++ b/ui/stage/fsr-panel.tsx
@@ -4,9 +4,13 @@ import { FsrSensor, type SMXPanelTestData } from "../../sdk";
 interface EnabledProps {
   testData: SMXPanelTestData | undefined;
   active: boolean | undefined;
+  disabled: boolean | undefined;
 }
 
-export function FsrPanel({ testData, active }: EnabledProps) {
+export function FsrPanel({ testData, active, disabled }: EnabledProps) {
+  if (disabled) {
+    return <div className={cn("panel", {})} />;
+  }
   return (
     <div
       className={cn("panel", {

--- a/ui/stage/load-cell-panel.tsx
+++ b/ui/stage/load-cell-panel.tsx
@@ -4,9 +4,13 @@ import { LoadCellSensor, type SMXPanelTestData } from "../../sdk";
 interface EnabledProps {
   testData: SMXPanelTestData | undefined;
   active: boolean | undefined;
+  disabled: boolean | undefined;
 }
 
-export function LoadCellPanel({ testData, active }: EnabledProps) {
+export function LoadCellPanel({ testData, active, disabled }: EnabledProps) {
+  if (disabled) {
+    return <div className={cn("panel", {})} />;
+  }
   return (
     <div
       className={cn("panel", {

--- a/ui/stage/stage-test.tsx
+++ b/ui/stage/stage-test.tsx
@@ -1,3 +1,4 @@
+import cn from "classnames";
 import { useAtomValue, type Atom } from "jotai";
 import type React from "react";
 import { useEffect, useState } from "react";
@@ -92,5 +93,5 @@ export function StageTest({
     ));
   }
 
-  return <div className="pad">{panels}</div>;
+  return <div className={cn("pad", { disabled: !stage })}>{panels}</div>;
 }

--- a/ui/stage/stage-test.tsx
+++ b/ui/stage/stage-test.tsx
@@ -6,7 +6,6 @@ import { type SMXStage, SensorTestMode, type SMXSensorTestData } from "../../sdk
 import { displayTestData$ } from "../state";
 import { timez } from "./util";
 import { LoadCellPanel } from "./load-cell-panel";
-import type { SMXConfig } from "../../sdk/commands/config";
 
 // UI Update Rate in Milliseconds
 const UI_UPDATE_RATE = 50;

--- a/ui/state.ts
+++ b/ui/state.ts
@@ -1,5 +1,5 @@
 import { atom, createStore } from "jotai";
-import { SensorTestMode, type SMXStage } from "../sdk";
+import type { SMXStage } from "../sdk";
 
 export const browserSupported = "hid" in navigator;
 
@@ -7,25 +7,18 @@ export const browserSupported = "hid" in navigator;
 export const uiState = createStore();
 
 /** backing atom of all known stages */
-export const stages$ = atom<Record<number, SMXStage | undefined>>({});
+export const stages$ = atom<Record<string, SMXStage>>({});
+
+export const selectedStageSerial$ = atom<string | undefined>(undefined);
+
+export const selectedStage$ = atom<SMXStage | undefined>((get) => {
+  const serial = get(selectedStageSerial$);
+  if (!serial) return;
+  const stages = get(stages$);
+  return stages[serial];
+});
 
 export const displayTestData$ = atom<"" | "raw" | "calibrated" | "noise" | "tare">("");
-
-/** current p1 pad, derived from devices$ above */
-export const p1Stage$ = atom<SMXStage | undefined, [SMXStage | undefined], void>(
-  (get) => get(stages$)[1],
-  (_, set, stage: SMXStage | undefined) => {
-    set(stages$, (prev) => ({ ...prev, [1]: stage }));
-  },
-);
-
-/** current p2 pad, derived from devices$ above */
-export const p2Stage$ = atom<SMXStage | undefined, [SMXStage | undefined], void>(
-  (get) => get(stages$)[2],
-  (_, set, stage: SMXStage | undefined) => {
-    set(stages$, (prev) => ({ ...prev, [2]: stage }));
-  },
-);
 
 export const statusText$ = atom(
   browserSupported

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -74,15 +74,36 @@ button:focus {
 }
 
 .pad {
+  position: relative;
   float: right;
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr; 
-  grid-template-rows: 1fr 1fr 1fr; 
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: 1fr 1fr 1fr;
   gap: 1em 1em;
-  height: 20em;
+  height: 26em;
   width: 20em;
   margin-right: 1em;
+  background-color: silver;
+  padding: 4em 1em 4em;
+  --corner-cut-size: 3em;
+  clip-path: polygon(var(--corner-cut-size) 0, calc(100% - var(--corner-cut-size)) 0, 100% var(--corner-cut-size), 100% calc(100% - var(--corner-cut-size)), calc(100% - var(--corner-cut-size)) 100%, var(--corner-cut-size) 100%, 0 calc(100% - var(--corner-cut-size)), 0 var(--corner-cut-size));
 }
+.pad::after {
+  /* its a bar! */
+  content: "";
+  text-align: center;
+  height: 1em;
+  width: 60%;
+  background-color: #222;
+  border-radius: 1em;
+  position: absolute;
+  bottom: 1.5em;
+  left: 20%;
+}
+.pad.disabled {
+  opacity: 0.5;
+}
+
 .panel {
   outline: 2px solid #ddd;
   position: relative;

--- a/ui/ui.tsx
+++ b/ui/ui.tsx
@@ -1,12 +1,19 @@
 import { useAtomValue, useAtom } from "jotai";
+import type React from "react";
 import { useEffect } from "react";
 
 import { DebugCommands } from "./DebugCommands.tsx";
 import { open_smx_device, promptSelectDevice } from "./pad-coms.ts";
-import { browserSupported, displayTestData$, p1Stage$, p2Stage$, statusText$ } from "./state.ts";
+import {
+  browserSupported,
+  displayTestData$,
+  selectedStage$,
+  selectedStageSerial$,
+  stages$,
+  statusText$,
+} from "./state.ts";
 import { StageTest } from "./stage/stage-test.tsx";
 import { TypedSelect } from "./common/typed-select.tsx";
-import { SensorTestMode } from "../sdk/index.ts";
 
 export function UI() {
   useEffect(() => {
@@ -29,10 +36,9 @@ export function UI() {
           (<a href="https://github.com/noahm/smx-config-web">source</a>)
         </small>
       </h1>
-      <StageTest stageAtom={p2Stage$} />
-      <StageTest stageAtom={p1Stage$} />
+      <StageTest stageAtom={selectedStage$} />
       <p>
-        <PickDeviceButton /> <DebugCommands />
+        <PickDevice /> <DebugCommands />
       </p>
       <p>
         <TestDataDisplayToggle />
@@ -42,11 +48,32 @@ export function UI() {
   );
 }
 
-function PickDeviceButton() {
+function PickDevice() {
+  const stages = useAtomValue(stages$);
+  const [selectedSerial, setSelectedSerial] = useAtom(selectedStageSerial$);
+  const handleChange: React.ChangeEventHandler<HTMLSelectElement> = (e) => {
+    const newValue = e.currentTarget.value;
+    if (newValue === "pair-new") {
+      promptSelectDevice();
+    } else {
+      setSelectedSerial(newValue);
+    }
+  };
+
   return (
-    <button type="button" disabled={!browserSupported} onClick={promptSelectDevice}>
-      Pick device...
-    </button>
+    <select value={selectedSerial || ""} disabled={!browserSupported} onChange={handleChange}>
+      {!selectedSerial ? (
+        <option disabled value="">
+          No Stage Selected
+        </option>
+      ) : null}
+      <option value="pair-new">Pair a stage...</option>
+      {Object.entries(stages).map(([serial, stage]) => (
+        <option value={serial} key={serial}>
+          P{stage.info?.player} - {serial}
+        </option>
+      ))}
+    </select>
   );
 }
 

--- a/ui/ui.tsx
+++ b/ui/ui.tsx
@@ -15,7 +15,7 @@ import {
 import { StageTest } from "./stage/stage-test.tsx";
 import { TypedSelect } from "./common/typed-select.tsx";
 
-export function UI() {
+function usePreviouslyPairedDevices() {
   useEffect(() => {
     // once, on load, get paired devices and attempt connection
     if (browserSupported) {
@@ -27,6 +27,10 @@ export function UI() {
       );
     }
   }, []);
+}
+
+export function UI() {
+  usePreviouslyPairedDevices();
 
   return (
     <>


### PR DESCRIPTION
Replaces the "Pick device..." button and player select drop-down with a single drop-down that allows you to pair any number of stages, and pick from the ones already paired.
![image](https://github.com/noahm/smx-config-web/assets/319485/75d973a4-8b2b-4047-b53c-14945bd10572)

Also updates the pad display to be one at a time only (the current selected stage) but it looks nicer now, almost like the real thing!
![image](https://github.com/noahm/smx-config-web/assets/319485/2cd79e97-66db-4359-ba8a-bb36c390e247)
