### PR TITLE
Correct config sizes for read/write old config

### DIFF
--- a/sdk/commands/config.ts
+++ b/sdk/commands/config.ts
@@ -1,6 +1,7 @@
 import { StructBuffer, bits, uint8_t, uint16_t, sbytes } from "@nmann/struct-buffer";
 import { EnabledSensors } from "./enabled-sensors.ts";
 import { Panel } from "../api.ts";
+import { padData } from "../utils.ts";
 
 export type Decoded<Struct extends { decode(...args: unknown[]): unknown }> = ReturnType<Struct["decode"]>;
 
@@ -361,8 +362,8 @@ export class SMXConfig {
       console.log("Reading Old Config");
 
       const slicedData = data.slice(2, -1);
-      const oldData = Uint8Array.from({ length: 250 }, (_, i) => slicedData[i] ?? 0);
-      this.oldConfig = smx_old_config_t.decode(oldData, true);
+      const paddedData = padData(slicedData, 250);
+      this.oldConfig = smx_old_config_t.decode(paddedData, true);
       this.config = this.convertOldToNew(this.oldConfig);
     }
   }

--- a/sdk/commands/config.ts
+++ b/sdk/commands/config.ts
@@ -344,6 +344,11 @@ const OLD_CONFIG_INIT = [
 export class SMXConfig {
   public config: Decoded<typeof smx_config_t>;
   private oldConfig: Decoded<typeof smx_old_config_t> | null = null;
+  /**
+   * some much older pads send smaller sized config data, so we need
+   * to keep track of how much they sent us and send back an appropriate
+   * sized config in the other direction
+   */
   private oldConfigSize: number | null = null;
   private firmwareVersion: number;
 
@@ -362,7 +367,9 @@ export class SMXConfig {
       console.log("Reading Old Config");
 
       const slicedData = data.slice(2, -1);
-      const paddedData = padData(slicedData, 250);
+      // handle very old stage's smaller config data by padding
+      // it out to the full size of the `smx_old_config_t` struct
+      const paddedData = padData(slicedData, smx_old_config_t.byteLength);
       this.oldConfig = smx_old_config_t.decode(paddedData, true);
       this.config = this.convertOldToNew(this.oldConfig);
     }

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -4,8 +4,12 @@ import { MAX_PACKET_SIZE } from "./packet.ts";
  * Pad incomming packet to `MAX_PACKET_SIZE` and convert to Uint8Array as a
  * final step before being sent to the device.
  */
-export function pad_packet(packet: Array<number>, padding = 0): Uint8Array {
-  return Uint8Array.from({ length: MAX_PACKET_SIZE }, (_, i) => packet[i] ?? 0);
+export function pad_packet(packet: ArrayLike<number>): Uint8Array {
+  return padData(packet, MAX_PACKET_SIZE);
+}
+
+export function padData(data: ArrayLike<number>, size: number, paddingValue = 0): Uint8Array {
+  return Uint8Array.from({ length: size }, (_, i) => data[i] ?? paddingValue);
 }
 
 export class RGB {


### PR DESCRIPTION
Extend the data when trying to create an old config object to 250 bytes, and truncate it if the original config size was 128 bytes or less when re-encoding to send back. 