### PR TITLE
Update enabled sensors to have its proper length again

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@mantine/hooks": "^9.0.0-alpha.3",
     "@mantine/modals": "^9.0.0-alpha.3",
     "@mantine/notifications": "^9.0.0-alpha.3",
-    "@nmann/struct-buffer": "^6.0.0-beta.1",
+    "@nmann/struct-buffer": "^6.1.1",
     "@tabler/icons-react": "^3.40.0",
     "baconjs": "patch:baconjs@npm%3A3.0.17#~/.yarn/patches/baconjs-npm-3.0.17-1a95474784.patch",
     "classnames": "^2.5.1",

--- a/sdk/commands/config.test.ts
+++ b/sdk/commands/config.test.ts
@@ -1,8 +1,6 @@
-import { expect, test } from "vitest";
+import { test } from "vitest";
 import { smx_config_t } from "./config";
 
-test.skip("struct size", () => {
-  const output = smx_config_t.encode({});
-  expect(output.byteLength).toBe(250);
-  expect(smx_config_t.byteLength).toBe(250);
+test("struct size", (t) => {
+  t.expect(smx_config_t.byteLength).toBe(250);
 });

--- a/sdk/commands/config.ts
+++ b/sdk/commands/config.ts
@@ -191,7 +191,7 @@ export const smx_config_t = new StructBuffer({
    *
    * Applications should leave any data in here unchanged when setting the Config.
    */
-  padding: uint8_t[44],
+  padding: uint8_t[49],
 });
 
 const NEW_CONFIG_INIT = [

--- a/sdk/commands/enabled-sensors.test.ts
+++ b/sdk/commands/enabled-sensors.test.ts
@@ -43,10 +43,26 @@ const decodedData = [
 
 const encodedData = "0f 0f ff 0f 00";
 
+test("size", () => {
+  expect(enabledSensors_t.byteLength).toBe(5);
+});
+
 test("decode", () => {
   expect(enabledSensors_t.decode(sbytes(encodedData))).toEqual(decodedData);
 });
 
 test("encode", () => {
   expect(sview(enabledSensors_t.encode(decodedData))).toEqual(encodedData);
+});
+
+describe("nested once", () => {
+  test("length", () => {
+    expect(enabledSensors_t[3].byteLength).toBe(15);
+  });
+  test("decode", () => {
+    expect(enabledSensors_t[2].decode(sbytes(encodedData + encodedData))).toEqual([decodedData, decodedData]);
+  });
+  test("encode", () => {
+    expect(sview(enabledSensors_t[2].encode([decodedData, decodedData]))).toEqual(encodedData + " " + encodedData);
+  });
 });

--- a/sdk/commands/enabled-sensors.ts
+++ b/sdk/commands/enabled-sensors.ts
@@ -1,5 +1,7 @@
-import { Inject, bits, uint8_t } from "@nmann/struct-buffer";
+import { bits, createDataView, makeDataView, uint8_t } from "@nmann/struct-buffer";
 import { SENSOR_COUNT, FsrSensor } from "../api";
+import type { LikeBuffer_t, IDecodeOptions, IBufferLike, IEncodeOptions } from "@nmann/struct-buffer/dist/interfaces";
+import { TypeDeep } from "@nmann/struct-buffer/dist/base/type-deep";
 
 type Decoded<Struct extends { decode(...args: unknown[]): unknown }> = ReturnType<Struct["decode"]>;
 
@@ -41,25 +43,61 @@ function joinTwoSensors(
 
 const BYTE_LENGTH = 5;
 
-/** very simple custom type that conveniently packs and unpacks 9 panels worth of four booleans each into 5 bytes */
-export const enabledSensors_t = new Inject<Array<Array<boolean>>, Array<Array<boolean>>>(
-  // decode
-  (view, offset) => {
-    const decoded = twoEnabledSensors_t[BYTE_LENGTH].decode(view, { offset }).flatMap<Array<boolean>>(splitTwoSensors);
+class Decorator<RawD, RawE, RichD, RichE>
+  extends TypeDeep<IBufferLike<RichD[], RichE[]>>
+  implements IBufferLike<RichD, RichE>
+{
+  constructor(
+    protected src: IBufferLike<RawD, RawE>,
+    protected transformD: (raw: RawD) => RichD,
+    protected transformE: (rich: RichE) => RawE,
+  ) {
+    super();
+  }
 
-    // decoded now has a trailing entry for the 4 bits of padding on the end of data
-    // so we slice to just the desired data
-    const value = decoded.slice(0, 9);
+  get byteLength() {
+    return this.src.byteLength * this.length;
+  }
 
-    return {
-      size: BYTE_LENGTH,
-      value,
-    };
-  },
-  // encode
-  (values) => {
+  decode(view: LikeBuffer_t, options?: IDecodeOptions | undefined): RichD {
+    const littleEndian = options?.littleEndian,
+      _view = makeDataView(view);
+
+    let offset = options?.offset ?? 0;
+
+    return this.resultEach([], () => {
+      const raw = this.src.decode(_view, { littleEndian, offset });
+      offset += this.src.byteLength;
+      return this.transformD(raw);
+    });
+  }
+
+  encode(obj: RichE, options?: IEncodeOptions): DataView {
+    let view = createDataView(this.byteLength, options?.view),
+      offset = options?.offset ?? 0;
+    const postTransformed = this.deepTransform(obj, this.deeps.length);
+    this.each(postTransformed, (raw) => {
+      console.log(raw);
+      view = this.src.encode(raw, { view, offset, littleEndian: options?.littleEndian });
+      offset += this.src.byteLength;
+    });
+    return view;
+  }
+  deepTransform(objList: RichE, depth: number): unknown {
+    if (!depth) return this.transformE(objList);
+    return (objList as RichE[]).map((obj) => this.deepTransform(obj, depth - 1));
+  }
+}
+
+export const enabledSensors_t = new Decorator(
+  twoEnabledSensors_t[5],
+  // decoding is just a matter of splitting each byte into
+  // each panel's group of 4 sensors, and then slicing off
+  // the non-existent tenth panel's zeros
+  (raw) => raw.flatMap(splitTwoSensors).slice(0, 9),
+  (values: boolean[][]) => {
     if (values.length !== 9) {
-      throw new TypeError("DisabledSensors only encodes sets of 9");
+      throw new TypeError(`DisabledSensors only encodes sets of 9, given ${values.length}`);
     }
     const joined: Array<Decoded<typeof twoEnabledSensors_t>> = [];
     for (let i = 0; i < BYTE_LENGTH; i++) {
@@ -67,6 +105,6 @@ export const enabledSensors_t = new Inject<Array<Array<boolean>>, Array<Array<bo
       const bIdx = aIdx + 1;
       joined.push(joinTwoSensors(values[aIdx], bIdx < values.length ? values[bIdx] : undefined));
     }
-    return twoEnabledSensors_t[BYTE_LENGTH].encode(joined);
+    return joined;
   },
 );

--- a/sdk/commands/enabled-sensors.ts
+++ b/sdk/commands/enabled-sensors.ts
@@ -1,7 +1,5 @@
-import { bits, createDataView, makeDataView, uint8_t } from "@nmann/struct-buffer";
+import { bits, Reshape, uint8_t } from "@nmann/struct-buffer";
 import { SENSOR_COUNT, FsrSensor } from "../api";
-import type { LikeBuffer_t, IDecodeOptions, IBufferLike, IEncodeOptions } from "@nmann/struct-buffer/dist/interfaces";
-import { TypeDeep } from "@nmann/struct-buffer/dist/base/type-deep";
 
 type Decoded<Struct extends { decode(...args: unknown[]): unknown }> = ReturnType<Struct["decode"]>;
 
@@ -43,59 +41,12 @@ function joinTwoSensors(
 
 const BYTE_LENGTH = 5;
 
-class Decorator<RawD, RawE, RichD, RichE>
-  extends TypeDeep<IBufferLike<RichD[], RichE[]>>
-  implements IBufferLike<RichD, RichE>
-{
-  constructor(
-    protected src: IBufferLike<RawD, RawE>,
-    protected transformD: (raw: RawD) => RichD,
-    protected transformE: (rich: RichE) => RawE,
-  ) {
-    super();
-  }
-
-  get byteLength() {
-    return this.src.byteLength * this.length;
-  }
-
-  decode(view: LikeBuffer_t, options?: IDecodeOptions | undefined): RichD {
-    const littleEndian = options?.littleEndian,
-      _view = makeDataView(view);
-
-    let offset = options?.offset ?? 0;
-
-    return this.resultEach([], () => {
-      const raw = this.src.decode(_view, { littleEndian, offset });
-      offset += this.src.byteLength;
-      return this.transformD(raw);
-    });
-  }
-
-  encode(obj: RichE, options?: IEncodeOptions): DataView {
-    let view = createDataView(this.byteLength, options?.view),
-      offset = options?.offset ?? 0;
-    const postTransformed = this.deepTransform(obj, this.deeps.length);
-    this.each(postTransformed, (raw) => {
-      console.log(raw);
-      view = this.src.encode(raw, { view, offset, littleEndian: options?.littleEndian });
-      offset += this.src.byteLength;
-    });
-    return view;
-  }
-  deepTransform(objList: RichE, depth: number): unknown {
-    if (!depth) return this.transformE(objList);
-    return (objList as RichE[]).map((obj) => this.deepTransform(obj, depth - 1));
-  }
-}
-
-export const enabledSensors_t = new Decorator(
-  twoEnabledSensors_t[5],
+export const enabledSensors_t = new Reshape(twoEnabledSensors_t[5], {
   // decoding is just a matter of splitting each byte into
   // each panel's group of 4 sensors, and then slicing off
   // the non-existent tenth panel's zeros
-  (raw) => raw.flatMap(splitTwoSensors).slice(0, 9),
-  (values: boolean[][]) => {
+  decode: (raw) => raw.flatMap(splitTwoSensors).slice(0, 9),
+  encode: (values: boolean[][]) => {
     if (values.length !== 9) {
       throw new TypeError(`DisabledSensors only encodes sets of 9, given ${values.length}`);
     }
@@ -107,4 +58,4 @@ export const enabledSensors_t = new Decorator(
     }
     return joined;
   },
-);
+});

--- a/sdk/commands/enabled-sensors.ts
+++ b/sdk/commands/enabled-sensors.ts
@@ -41,6 +41,10 @@ function joinTwoSensors(
 
 const BYTE_LENGTH = 5;
 
+/**
+ * simple custom type that packs and unpacks all 9 panels
+ * worth of four-lenth tuples of booleans from the source 5 bytes
+ **/
 export const enabledSensors_t = new Reshape(twoEnabledSensors_t[5], {
   // decoding is just a matter of splitting each byte into
   // each panel's group of 4 sensors, and then slicing off

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,10 +279,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nmann/struct-buffer@npm:^6.0.0-beta.1":
-  version: 6.0.1
-  resolution: "@nmann/struct-buffer@npm:6.0.1"
-  checksum: 10c0/afb68b888a9f4fa71ef3b672678d8329a5b9d94e558b5aa285c8772a1574817359121770998ebc8fc83dc7ea7c3f29e0dc297f2748cd6361ab1e714cd7524bed
+"@nmann/struct-buffer@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "@nmann/struct-buffer@npm:6.1.1"
+  checksum: 10c0/657b6e549bd799e4428b9bb5efd3488fd5bcf1b91f9a9d9f56335c94041e3b10dc6d5288e0b0fe7cb42790f40e08d59663f17a719b935a8a2be770105833afd9
   languageName: node
   linkType: hard
 
@@ -1685,7 +1685,7 @@ __metadata:
     "@mantine/hooks": "npm:^9.0.0-alpha.3"
     "@mantine/modals": "npm:^9.0.0-alpha.3"
     "@mantine/notifications": "npm:^9.0.0-alpha.3"
-    "@nmann/struct-buffer": "npm:^6.0.0-beta.1"
+    "@nmann/struct-buffer": "npm:^6.1.1"
     "@tabler/icons-react": "npm:^3.40.0"
     "@types/node": "npm:^24.0.0"
     "@types/react": "npm:^19.2.0"


### PR DESCRIPTION
The `Inject` operator I had been using before was designed to let you capture data of arbitrary length (C style strings?) and as such did not report a length at all, which led to other weird issues. I went into the underlying struct-buffer package and added a new `Reshape` decorator that just lets you transform data for ergonomics while still maintaining the fixed size of the underlying struct definition. Switching over to that fixes all the oddities around these enabled sensors and cleans the code up a bit compared to `Inject` too!